### PR TITLE
chore(deps): 依存性アップデート適用 (Issue #36)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,3 @@
 [tools]
 node = "24.16.0"
-"npm:pnpm" = "11.5.2"
+"npm:pnpm" = "11.6.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "音源名を管理するためのCLIツール",
   "type": "module",
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.6.0",
   "scripts": {
     "start": "tsx src/index.ts",
     "test": "vitest run",
@@ -23,7 +23,7 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
-    "@types/node": "25.9.1",
+    "@types/node": "25.9.2",
     "husky": "9.1.7",
     "tsx": "4.22.4",
     "typescript": "6.0.3",
@@ -31,7 +31,7 @@
   },
   "engines": {
     "node": "24.16.0",
-    "pnpm": "11.5.2"
+    "pnpm": "11.6.0"
   },
   "dependencies": {
     "commander": "15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: 2.4.16
         version: 2.4.16
       '@types/node':
-        specifier: 25.9.1
-        version: 25.9.1
+        specifier: 25.9.2
+        version: 25.9.2
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -32,7 +32,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@types/node@25.9.1)(vite@7.3.2(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.2)(vite@7.3.2(@types/node@25.9.2)(tsx@4.22.4)(yaml@2.9.0))
 
 packages:
 
@@ -558,8 +558,8 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+  '@types/node@25.9.2':
+    resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
 
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
@@ -1087,7 +1087,7 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/node@25.9.1':
+  '@types/node@25.9.2':
     dependencies:
       undici-types: 7.24.6
 
@@ -1100,13 +1100,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.2(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@7.3.2(@types/node@25.9.2)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@25.9.2)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -1295,7 +1295,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  vite@7.3.2(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0):
+  vite@7.3.2(@types/node@25.9.2)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1304,15 +1304,15 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
       fsevents: 2.3.3
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@25.9.1)(vite@7.3.2(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.2)(vite@7.3.2(@types/node@25.9.2)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.2(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@7.3.2(@types/node@25.9.2)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -1329,10 +1329,10 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.9.1)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@25.9.2)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 25.9.2
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## 概要

依存性チェックレポート 2026-06-15（Issue #36）対応。

- pnpm 11.5.2 → 11.6.0（`packageManager` / `engines.pnpm` / `.mise.toml`）
- @types/node 25.9.1 → 25.9.2
- pnpm-lock.yaml 更新

Closes #36

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `.mise.toml` | pnpm バージョンを 11.5.2 → 11.6.0 に更新 |
| `package.json` | `packageManager` / `engines.pnpm` を 11.6.0 に、`@types/node` を 25.9.2 に更新 |
| `pnpm-lock.yaml` | `pnpm install` による lockfile 更新 |

## 検証結果

- `pnpm run check` 成功
- `pnpm test` 成功（164 テスト pass）