### PR TITLE
chore(biome): $schema を node_modules 相対パスに変更

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "javascript": {
     "formatter": {


### PR DESCRIPTION
## 概要
- biome.json の `$schema` フィールドを固定バージョンの URL からローカルパッケージ参照に変更

## 変更内容
- `$schema` を `https://biomejs.dev/schemas/2.5.1/schema.json` から `./node_modules/@biomejs/biome/configuration_schema.json` に変更
- biome のバージョンアップ時にスキーマ URL のバージョン番号を手動で書き換える必要がなくなる

## テスト計画
- biome.json の変更のみのため、コマンド実行による動作確認は未実施

Closes #44